### PR TITLE
Fix pools apr

### DIFF
--- a/src/state/pools/fetchPools.ts
+++ b/src/state/pools/fetchPools.ts
@@ -1,10 +1,9 @@
 import BigNumber from 'bignumber.js'
-import poolsConfig from 'config/constants/pools'
-import wkdPoolABI from 'config/abi/wkdPool.json'
 import erc20ABI from 'config/abi/erc20.json'
-import multicall from 'utils/multicall'
+import wkdPoolABI from 'config/abi/wkdPool.json'
+import poolsConfig from 'config/constants/pools'
 import { getAddress } from 'utils/addressHelpers'
-import { formatUnits } from '@ethersproject/units'
+import multicall from 'utils/multicall'
 
 const poolsWithEnd = poolsConfig.filter((p) => p.sousId !== 0)
 
@@ -70,9 +69,10 @@ export const fetchPoolsTotalStaking = async () => {
   return poolsConfig.map((p, index) => ({
     sousId: p.sousId,
     // the first pool is having the stakingtoken and earning token as wkd, this is a workaround to ensure we dont don't add the tokens in the contract for reward to the total staked
-    totalStaked:
-      p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
-        ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
-        : new BigNumber(balances[index]).toJSON(),
+    // totalStaked:
+    //   p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
+    //     ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
+    //     : new BigNumber(balances[index]).toJSON(),
+    totalStaked: new BigNumber(balances[index]).toJSON(),
   }))
 }

--- a/src/state/pools/fetchPools.ts
+++ b/src/state/pools/fetchPools.ts
@@ -54,13 +54,13 @@ const poolsBalanceOf = poolsConfig.map((poolConfig) => {
   }
 })
 
-const availableRewards = poolsConfig.map((poolConfig) => {
-  return {
-    address: getAddress(poolConfig.contractAddress),
-    name: 'availableRewards',
-    params: [],
-  }
-})
+// const availableRewards = poolsConfig.map((poolConfig) => {
+//   return {
+//     address: getAddress(poolConfig.contractAddress),
+//     name: 'availableRewards',
+//     params: [],
+//   }
+// })
 
 export const fetchPoolsTotalStaking = async () => {
   const balances = await multicall(erc20ABI, poolsBalanceOf)

--- a/src/state/pools/fetchPools.ts
+++ b/src/state/pools/fetchPools.ts
@@ -64,7 +64,7 @@ const availableRewards = poolsConfig.map((poolConfig) => {
 
 export const fetchPoolsTotalStaking = async () => {
   const balances = await multicall(erc20ABI, poolsBalanceOf)
-  const rewards = await multicall(wkdPoolABI, availableRewards)
+  // const rewards = await multicall(wkdPoolABI, availableRewards)
 
   return poolsConfig.map((p, index) => ({
     sousId: p.sousId,

--- a/src/state/pools/fetchPools.ts
+++ b/src/state/pools/fetchPools.ts
@@ -69,9 +69,10 @@ export const fetchPoolsTotalStaking = async () => {
   return poolsConfig.map((p, index) => ({
     sousId: p.sousId,
     // the first pool is having the stakingtoken and earning token as wkd, this is a workaround to ensure we dont don't add the tokens in the contract for reward to the total staked
-    totalStaked:
-      p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
-        ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
-        : new BigNumber(balances[index]).toJSON(),
+    // totalStaked:
+    //   p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
+    //     ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
+    //     : new BigNumber(balances[index]).toJSON(),
+    totalStaked: new BigNumber(balances[index]).toJSON(),
   }))
 }

--- a/src/state/pools/fetchPools.ts
+++ b/src/state/pools/fetchPools.ts
@@ -69,10 +69,9 @@ export const fetchPoolsTotalStaking = async () => {
   return poolsConfig.map((p, index) => ({
     sousId: p.sousId,
     // the first pool is having the stakingtoken and earning token as wkd, this is a workaround to ensure we dont don't add the tokens in the contract for reward to the total staked
-    // totalStaked:
-    //   p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
-    //     ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
-    //     : new BigNumber(balances[index]).toJSON(),
-    totalStaked: new BigNumber(balances[index]).toJSON(),
+    totalStaked:
+      p.stakingToken.address.toLowerCase() === p.earningToken.address.toLowerCase()
+        ? new BigNumber(balances[index]).minus(new BigNumber(rewards[index])).toJSON()
+        : new BigNumber(balances[index]).toJSON(),
   }))
 }


### PR DESCRIPTION
![Screenshot 2024-02-08 103548](https://github.com/649bc/wakanda-inu-dex/assets/43646844/95aae122-9426-483c-aa18-7f9c7f9c5bc9)
Imagine someone thinking it is a good idea to subtract the long reward value from the small totalstaked value (bal)   🤦‍♂️
That resulted in a very negative value and that led to the current 0 % APR displayed
All of these happened just because they removed the original pancake code and replaced it with something else (again) 🌚
 
After replacing their addition with the original code from pancake repo for that version, we have the page working like it should again
![Corected Negative APR](https://github.com/649bc/wakanda-inu-dex/assets/43646844/52253b90-8f4d-4362-a5d7-853ad509f758)

I have tested it, and Staking and harvesting work like they used to.

**Disclaimer**
- As usual, I have no idea if anything else is broken.
- if anything else is broken, all I changed is one line of code, so it is definitely not me 🌚
